### PR TITLE
Fix outdated .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,11 @@ docker-compose.yml
 Dockerfile
 .dockerignore
 
-# Image build script
-build.sh
-
+# Git files
 .gitignore
+.git/
+
+# Additional files
+LICENSE
+README.md
+


### PR DESCRIPTION
The `.dockerignore` file determines which files are sent to the build context when building a Docker images.
Transferring the `.git` directory unnecessarily blows up image size.